### PR TITLE
feat: show Open Graph images for each page in docs

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -54,11 +54,6 @@
       },
 
       {
-        property: 'og:image',
-        content: '/img/icons/favicon/favicon-200x200.png',
-      },
-
-      {
         property: 'twitter:card',
         content: 'summary_large_image',
       },
@@ -77,11 +72,6 @@
         property: 'twitter:description',
         content:
           'Vulmix helps you to create faster Vue SPAs with little effort.',
-      },
-
-      {
-        property: 'twitter:image',
-        content: '/img/icons/favicon/favicon-200x200.png',
       },
     ],
 

--- a/app.vue
+++ b/app.vue
@@ -18,10 +18,6 @@
 
     meta: [
       {
-        charset: 'utf-8',
-      },
-
-      {
         name: 'description',
         content:
           'Vulmix helps you to create faster Vue SPAs with little effort.',
@@ -30,48 +26,6 @@
       {
         name: 'author',
         content: 'Victor Ribeiro',
-      },
-
-      {
-        property: 'og:type',
-        content: 'website',
-      },
-
-      {
-        property: 'og:url',
-        content: 'https://vulmix.vercel.app/',
-      },
-
-      {
-        property: 'og:title',
-        content: 'Vulmix - Create faster Vue single page apps',
-      },
-
-      {
-        property: 'og:description',
-        content:
-          'Vulmix helps you to create faster Vue SPAs with little effort.',
-      },
-
-      {
-        property: 'twitter:card',
-        content: 'summary_large_image',
-      },
-
-      {
-        property: 'twitter:url',
-        content: 'https://vulmix.vercel.app/',
-      },
-
-      {
-        property: 'twitter:title',
-        content: 'Vulmix - Create faster Vue single page apps',
-      },
-
-      {
-        property: 'twitter:description',
-        content:
-          'Vulmix helps you to create faster Vue SPAs with little effort.',
       },
     ],
 

--- a/components/islands/ContentOgImage.vue
+++ b/components/islands/ContentOgImage.vue
@@ -17,10 +17,10 @@
 
     <div class="absolute inset-0 flex flex-col items-center justify-center">
       <div
-        class="flex z-10 absolute flex-col items-center justify-center gap-5"
+        class="flex absolute flex-col items-center justify-center gap-5"
       >
         <div class="mb-12">
-          <img src="/img/vulmix-logo.svg" class="h-36" />
+          <img src="/img/vulmix-logo.svg" height="144" />
         </div>
 
         <div class="mb-8">

--- a/components/islands/HomeOgImage.vue
+++ b/components/islands/HomeOgImage.vue
@@ -17,10 +17,10 @@
 
     <div class="absolute inset-0 flex flex-col items-center justify-center">
       <div
-        class="flex z-10 absolute flex-col items-center justify-center gap-5"
+        class="flex absolute flex-col items-center justify-center gap-5"
       >
         <div class="mb-8">
-          <img src="/img/vulmix-logo.svg" class="h-56" />
+          <img src="/img/vulmix-logo.svg" height="224" />
         </div>
 
         <div class="text-white/70 text-4xl font-bold">vulmix.dev</div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,6 +30,5 @@ export default defineNuxtConfig({
         },
       },
     },
-    siteUrl: 'https://vulmix.vercel.app/',
   },
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "autoprefixer": "^10.4.14",
     "nuxt": "^3.5.3",
     "nuxt-icon": "^0.1.8",
-    "nuxt-og-image": "2.0.0-beta.51",
+    "nuxt-og-image": "2.0.0-beta.52",
     "postcss": "^8.4.24",
     "sass": "^1.62.1",
     "sass-loader": "^10.4.1",
@@ -24,4 +24,3 @@
     "@vueuse/nuxt": "^9.13.0"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "autoprefixer": "^10.4.14",
     "nuxt": "^3.5.3",
     "nuxt-icon": "^0.1.8",
-    "nuxt-og-image": "2.0.0-beta.52",
+    "nuxt-og-image": "2.0.0-beta.58",
     "postcss": "^8.4.24",
     "sass": "^1.62.1",
     "sass-loader": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3159,6 +3159,13 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+image-size@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
+
 immutable@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.0.tgz#eb1738f14ffb39fd068b1dbe1296117484dd34be"
@@ -4545,10 +4552,10 @@ nuxt-icon@^0.4.1:
     "@iconify/vue" "^4.1.1"
     "@nuxt/kit" "^3.5.0"
 
-nuxt-og-image@2.0.0-beta.52:
-  version "2.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/nuxt-og-image/-/nuxt-og-image-2.0.0-beta.52.tgz#e2afcfab06dba40189b55bd3656b7c99ff3b349d"
-  integrity sha512-3Tr+xuB8BhNbtq9GRNcaHW8di1jfLqNcIdwgU4oJ0uSU+oVzAJIzipnevTO46GYn/u3ypzKshMKLJIA688uvqg==
+nuxt-og-image@2.0.0-beta.58:
+  version "2.0.0-beta.58"
+  resolved "https://registry.yarnpkg.com/nuxt-og-image/-/nuxt-og-image-2.0.0-beta.58.tgz#800a61463b1d2b2ff0ce87ba368f941a45dcdf7f"
+  integrity sha512-Vh0QagpL8trwFocgk5Cete6Jt5FXlVjG4CX7ZWwF40N8Sz7BP+VKO3YV4qi+78eQmGJCKltWqhqzB6IN4APC3A==
   dependencies:
     "@nuxt/kit" "^3.5.3"
     "@resvg/resvg-js" "^2.4.1"
@@ -4563,6 +4570,7 @@ nuxt-og-image@2.0.0-beta.52:
     flatted "^3.2.7"
     fs-extra "^11.1.1"
     globby "^13.1.4"
+    image-size "^1.0.2"
     inline-css "^4.0.2"
     launch-editor "^2.6.0"
     nuxt-icon "^0.4.1"
@@ -4571,7 +4579,7 @@ nuxt-og-image@2.0.0-beta.52:
     ofetch "^1.1.0"
     ohash "^1.1.2"
     pathe "^1.1.1"
-    playwright-core "^1.34.3"
+    playwright-core "^1.35.0"
     radix3 "^1.0.1"
     satori "0.10.1"
     satori-html "^0.3.2"
@@ -4941,10 +4949,10 @@ pkg-types@^1.0.2, pkg-types@^1.0.3:
     mlly "^1.2.0"
     pathe "^1.1.0"
 
-playwright-core@^1.34.3:
-  version "1.34.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.34.3.tgz#bc906ea1b26bb66116ce329436ee59ba2e78fe9f"
-  integrity sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==
+playwright-core@^1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.0.tgz#b7871b742b4a5c8714b7fa2f570c280a061cb414"
+  integrity sha512-muMXyPmIx/2DPrCHOD1H1ePT01o7OdKxKj2ebmCAYvqhUy+Y1bpal7B0rdoxros7YrXI294JT/DWw2LqyiqTPA==
 
 postcss-calc@^9.0.0:
   version "9.0.1"
@@ -5285,6 +5293,13 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 radix3@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4545,10 +4545,10 @@ nuxt-icon@^0.4.1:
     "@iconify/vue" "^4.1.1"
     "@nuxt/kit" "^3.5.0"
 
-nuxt-og-image@2.0.0-beta.51:
-  version "2.0.0-beta.51"
-  resolved "https://registry.yarnpkg.com/nuxt-og-image/-/nuxt-og-image-2.0.0-beta.51.tgz#ba1789621851d8eae5b6270bcc89fd4035aaa6ea"
-  integrity sha512-hx77w6elXKEOaLLt20UsQQDK57tCFB8FAGl1K84bj/bCqkiPokPkCfqCNywsAYxzy+e3roVUU1aZEi43h8WbLw==
+nuxt-og-image@2.0.0-beta.52:
+  version "2.0.0-beta.52"
+  resolved "https://registry.yarnpkg.com/nuxt-og-image/-/nuxt-og-image-2.0.0-beta.52.tgz#e2afcfab06dba40189b55bd3656b7c99ff3b349d"
+  integrity sha512-3Tr+xuB8BhNbtq9GRNcaHW8di1jfLqNcIdwgU4oJ0uSU+oVzAJIzipnevTO46GYn/u3ypzKshMKLJIA688uvqg==
   dependencies:
     "@nuxt/kit" "^3.5.3"
     "@resvg/resvg-js" "^2.4.1"


### PR DESCRIPTION
Thanks to @harlan-zw's [`nuxt-og-image`](https://github.com/harlan-zw/nuxt-og-image) Nuxt module, now Vulmix docs generates Open Graph images for each page.